### PR TITLE
Anonymous Token in SecurityContext by default

### DIFF
--- a/src/Trolamine/Core/SimpleSecurityContext.php
+++ b/src/Trolamine/Core/SimpleSecurityContext.php
@@ -2,6 +2,7 @@
 namespace Trolamine\Core;
 
 use Trolamine\Core\Authentication\Authentication;
+use Trolamine\Core\Authentication\AnonymousAuthenticationToken;
 use Trolamine\Core\Access\AccessDecisionManager;
 use Trolamine\Core\Operation\MethodSecurityExpressionRoot;
 use Trolamine\Core\Exception\InsufficientAuthenticationException;
@@ -10,19 +11,19 @@ use Trolamine\Core\Access\OperationConfigAttribute;
 
 class SimpleSecurityContext implements SecurityContext
 {
-    
+
     /**
      *
      * @var Authentication
      */
     protected $authentication;
-    
+
     /**
      *
      * @var AccessDecisionManager
      */
     protected $accessDecisionManager;
-    
+
     /**
      * Constructor
      *
@@ -31,29 +32,30 @@ class SimpleSecurityContext implements SecurityContext
     public function __construct(AccessDecisionManager $accessDecisionManager)
     {
         $this->accessDecisionManager = $accessDecisionManager;
+        $this->authentication = new AnonymousAuthenticationToken();
     }
-    
+
     public function setAuthentication(Authentication $authentication)
     {
         $this->authentication = $authentication;
     }
-    
+
     public function getAuthentication()
     {
         return $this->authentication;
     }
-    
-    
+
+
     public function getAccessDecisionManager()
     {
         return $this->accessDecisionManager;
     }
-    
+
     public function hasRole($roleName)
     {
         $roleOperation = new MethodSecurityExpressionRoot();
         $roleConfigAttribute = new OperationConfigAttribute($roleOperation, 'hasRole', array($roleName));
-        
+
         try {
             $this->accessDecisionManager->decide($this->authentication, null, array($roleConfigAttribute));
         } catch (AccessDeniedException $ade) {
@@ -63,7 +65,7 @@ class SimpleSecurityContext implements SecurityContext
         } catch (\Exception $e) {
             throw $e;
         }
-        
+
         return true;
     }
 
@@ -71,7 +73,7 @@ class SimpleSecurityContext implements SecurityContext
     {
         $roleOperation = new MethodSecurityExpressionRoot();
         $roleConfigAttribute = new OperationConfigAttribute($roleOperation, 'hasAnyRole', array($roles));
-        
+
         try {
             $this->accessDecisionManager->decide($this->authentication, null, array($roleConfigAttribute));
         } catch (AccessDeniedException $ade) {
@@ -81,7 +83,7 @@ class SimpleSecurityContext implements SecurityContext
         } catch (\Exception $e) {
             throw $e;
         }
-        
+
         return true;
     }
 }


### PR DESCRIPTION
When we don't provide a Token to the SecurityContext, we may have crashes because the token is expected behind the scene...
So I've added an AnonymousToken by default in the SecurityContext